### PR TITLE
Minor code cleanup

### DIFF
--- a/src/main/java/org/fxmisc/livedirs/DirWatcher.java
+++ b/src/main/java/org/fxmisc/livedirs/DirWatcher.java
@@ -43,7 +43,7 @@ class DirWatcher {
 
     public DirWatcher(Executor eventThreadExecutor) throws IOException {
         this.watcher = FileSystems.getDefault().newWatchService();
-        this.ioThread = new Thread(() -> loop(), "DirWatchIO");
+        this.ioThread = new Thread(this::loop, "DirWatchIO");
         this.eventThreadExecutor = eventThreadExecutor;
         this.ioThread.start();
     }
@@ -282,7 +282,7 @@ class PathNode {
             try(Stream<Path> dirStream = Files.list(root)) {
                 childPaths = dirStream
                         .sorted(PATH_COMPARATOR)
-                        .toArray(i -> new Path[i]);
+                        .toArray(Path[]::new);
             }
             List<PathNode> children = new ArrayList<>(childPaths.length);
             for(Path p: childPaths) {

--- a/src/main/java/org/fxmisc/livedirs/LiveDirs.java
+++ b/src/main/java/org/fxmisc/livedirs/LiveDirs.java
@@ -71,7 +71,7 @@ public class LiveDirs<I> {
         this.model = new LiveDirsModel<>(externalInitiator);
         this.io = new LiveDirsIO<>(dirWatcher, model, clientThreadExecutor);
 
-        this.dirWatcher.signalledKeys().subscribe(key -> processKey(key));
+        this.dirWatcher.signalledKeys().subscribe(this::processKey);
         this.errors = EventStreams.merge(dirWatcher.errors(), model.errors(), localErrors);
     }
 

--- a/src/main/java/org/fxmisc/livedirs/LiveDirsIO.java
+++ b/src/main/java/org/fxmisc/livedirs/LiveDirsIO.java
@@ -25,7 +25,7 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
                     model.addFile(file, initiator, lastModified);
                     created.complete(null);
                 },
-                error -> created.completeExceptionally(error));
+                created::completeExceptionally);
         return wrap(created);
     }
 
@@ -40,7 +40,7 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
                     }
                     created.complete(null);
                 },
-                error -> created.completeExceptionally(error));
+                created::completeExceptionally);
         return wrap(created);
     }
 
@@ -52,7 +52,7 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
                     model.updateModificationTime(file, lastModified, initiator);
                     saved.complete(null);
                 },
-                error -> saved.completeExceptionally(error));
+                saved::completeExceptionally);
         return wrap(saved);
     }
 
@@ -64,7 +64,7 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
                     model.updateModificationTime(file, lastModified, initiator);
                     saved.complete(null);
                 },
-                error -> saved.completeExceptionally(error));
+                saved::completeExceptionally);
         return wrap(saved);
     }
 
@@ -76,7 +76,7 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
                     model.delete(file, initiator);
                     deleted.complete(null);
                 },
-                error -> deleted.completeExceptionally(error));
+                deleted::completeExceptionally);
         return wrap(deleted);
     }
 
@@ -88,7 +88,7 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
                     model.delete(root, initiator);
                     deleted.complete(null);
                 },
-                error -> deleted.completeExceptionally(error));
+                deleted::completeExceptionally);
         return wrap(deleted);
     }
 
@@ -96,8 +96,8 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
     public CompletionStage<String> loadTextFile(Path file, Charset charset) {
         CompletableFuture<String> loaded = new CompletableFuture<>();
         dirWatcher.loadTextFile(file, charset,
-                content -> loaded.complete(content),
-                error -> loaded.completeExceptionally(error));
+                loaded::complete,
+                loaded::completeExceptionally);
         return wrap(loaded);
     }
 
@@ -105,8 +105,8 @@ class LiveDirsIO<I> implements InitiatorTrackingIOFacility<I> {
     public CompletionStage<byte[]> loadBinaryFile(Path file) {
         CompletableFuture<byte[]> loaded = new CompletableFuture<>();
         dirWatcher.loadBinaryFile(file,
-                content -> loaded.complete(content),
-                error -> loaded.completeExceptionally(error));
+                loaded::complete,
+                loaded::completeExceptionally);
         return wrap(loaded);
     }
 

--- a/src/main/java/org/fxmisc/livedirs/LiveDirsModel.java
+++ b/src/main/java/org/fxmisc/livedirs/LiveDirsModel.java
@@ -117,7 +117,7 @@ class LiveDirsModel<I> implements DirectoryModel<I> {
 
     private List<TopLevelDirItem<I>> getTopLevelAncestors(Path path) {
         return Arrays.asList(topLevelAncestorStream(path)
-                .toArray(i -> new TopLevelDirItem[i]));
+                .<TopLevelDirItem<I>>toArray(TopLevelDirItem[]::new));
     }
 
     private List<TopLevelDirItem<I>> getTopLevelAncestorsNonEmpty(Path path) {


### PR DESCRIPTION
- Specified `toArray` generic
- Convert lambdas to method references where possible

Let's be honest. I should have done this first before since I end up redoing it in every new branch I try out.