### PR TITLE
Correcting a redundant invokation of pollEvents method, that was perm…

### DIFF
--- a/livedirsfx/src/main/java/org/fxmisc/livedirs/LiveDirs.java
+++ b/livedirsfx/src/main/java/org/fxmisc/livedirs/LiveDirs.java
@@ -163,7 +163,7 @@ public class LiveDirs<I, T> {
             if(events.stream().anyMatch(evt -> evt.kind() == OVERFLOW)) {
                 refreshOrLogError(dir);
             } else {
-                for(WatchEvent<?> evt: key.pollEvents()) {
+                for(WatchEvent<?> evt: events) {
                     @SuppressWarnings("unchecked")
                     WatchEvent<Path> event = (WatchEvent<Path>) evt;
                     processEvent(dir, event);


### PR DESCRIPTION
…anently emptying the event queue.

The project invokes "pollEvents" twice, consecutively : one time (l162) as the "events" variable is initialized and one more time immediately after, in the for loop (l166).
 Watchkey documentation tells:
"Events are retrieved by invoking the key's pollEvents method. This method retrieves and removes all events accumulated for the object."
As a consequence, the for loop tries continuously to scan an emptied liste of events because no file event could happen inbetween.
The solution is to use the created variable ("events") instead of re-invoking the pollEvents method on line 166.

It was for me the only way to make directories display. Hope this helps (far from beeing an experienced coder).